### PR TITLE
added execute command for python >2.5

### DIFF
--- a/README
+++ b/README
@@ -1,4 +1,3 @@
-
 ========
 bosnobot
 ========
@@ -114,6 +113,11 @@ Running the Bot
 To run the bot based on its installation above you can simply execute::
 
     python -m bosnobot
+    
+For python version >2.5, the above command won't work due to a regression(http://bugs.python.org/issue2751).
+To run the bot, execute:
+
+   python -c "import bosnobot; bosnobot.main()"
 
 Need more help?
 ===============


### PR DESCRIPTION
The command 'python -m bosnobot' works only for python2.5 because of a regression.
So, for python >2.5 (I tested it on 2.7), the module has to be imported and then run
